### PR TITLE
Added support for Honor 8 64GB

### DIFF
--- a/app/src/main/java/it/mobimentum/dualsimwidget/DualSimPhone.java
+++ b/app/src/main/java/it/mobimentum/dualsimwidget/DualSimPhone.java
@@ -28,6 +28,10 @@ public class DualSimPhone {
 		// Huawei P9
 		SUPPORTED_PHONES.add(new DualSimPhone("HUAWEI", "EVA-AL10",
 				new Intent().setComponent(new ComponentName("com.android.settings", "com.android.settings.DualCardSettings"))));
+
+		// Honor 8 64GB
+		SUPPORTED_PHONES.add(new DualSimPhone("HONOR", "FRD-L19",
+				new Intent().setComponent(new ComponentName("com.android.settings", "com.android.settings.DualCardSettings"))));
 	}
 
 	public static Intent getDualSimSettingsIntent() {


### PR DESCRIPTION
I can confirm that Honor 8 uses the same Intent as Huawei P9. I added the brand and model info of my phone (Honor 8 64GB), and it works and directly opens the dual sim settings page. It seems that for example http://www.phonemore.com/huawei-honor-8/models/629 has the model infos of other Honor 8 dual sim variants (the first FRD-L04 is a single sim variant).